### PR TITLE
Clipboard addition and CatFact correction

### DIFF
--- a/my_app/lib/exercises/networking/main.dart
+++ b/my_app/lib/exercises/networking/main.dart
@@ -30,8 +30,8 @@ class CatFact {
 
   factory CatFact.fromJson(Map<String, dynamic> parsedJson){
     return CatFact(
-      text: parsedJson['id'],
-      id : parsedJson['name'],
+      text: parsedJson['text'],
+      id : parsedJson['_id'],
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@vuepress/plugin-active-header-links": "^1.0.0-alpha.42"
   },
   "dependencies": {
+    "@dovyp/vuepress-plugin-clipboard-copy": "^1.0.0-alpha.7",
     "vuepress": "^1.0.4"
   }
 }

--- a/workshop/.vuepress/config.js
+++ b/workshop/.vuepress/config.js
@@ -53,6 +53,7 @@ module.exports = {
       sidebarLinkSelector: ".sidebar-link",
       headerAnchorSelector: ".header-anchor",
       headerTopOffset: 120
-    }
+    },
+    ['@dovyp/vuepress-plugin-clipboard-copy', true]
   ]
 };


### PR DESCRIPTION
During GDG Porto Flutter Studyjam (21/09/2019) the following issues have been pointed out:

- No clipboard functionality on code snippets
- CatFact PODO has different json identifiers

For clipboard interaction @dovy plugin has been used (https://github.com/vuejs/vuepress/issues/703#issuecomment-477257349)

